### PR TITLE
Support installing multiple archive formats on macOS

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -47,7 +47,6 @@ _get_download_url() {
 install() {
   local -r version=$1
   local -r install_path=$2
-  echo "${version}, ${install_path}"
 
   local -r platform="$(_get_platform)"
   local -r arch="$(_get_arch)"

--- a/bin/install
+++ b/bin/install
@@ -51,8 +51,66 @@ install() {
 
   local -r platform="$(_get_platform)"
   local -r arch="$(_get_arch)"
-  local -r download_url="$(_get_download_url "$version" "$platform" "$arch" ".tar.gz")"
-  echo "${download_url}"
+
+  local -r tarball_url="$(_get_download_url "$version" "$platform" "$arch" ".tar.gz")"
+  local -r zip_url="$(_get_download_url "$version" "$platform" "$arch" ".zip")"
+
+  case $platform in
+  linux)
+    install_tarball "$install_path" "$tarball_url"
+    ;;
+  darwin)
+    local -r code=$(curl -o /dev/null --silent -LIw '%{http_code}' "${tarball_url}")
+    if [ "$code" = "200" ]
+    then
+      install_tarball "$install_path" "$tarball_url"
+    else
+      install_zip "$install_path" "$zip_url"
+    fi
+    ;;
+  esac
+}
+
+install_tarball() {
+  local -r install_path=$1
+  local -r url=$2
+
+  local -r tar_install_path="$install_path/syft-v$version.tgz"
+  local -r bin_install_path="$install_path/bin"
+  local -r bin_path="$bin_install_path/syft"
+
+  mkdir -p "$bin_install_path"
+  local tmp_dir
+  tmp_dir="$(mktemp -d)"
+
+  echo "Downloading syft from $url"
+  curl -Ls "$url" -o "$tar_install_path"
+  tar -xf "$tar_install_path" -C "$tmp_dir"
+  cp "${tmp_dir}/syft" "$bin_path"
+  rm -rf "$tar_install_path"
+  rm -rf "$tmp_dir"
+  chmod +x "$bin_path"
+}
+
+install_zip() {
+  local -r install_path=$1
+  local -r url=$2
+
+  local -r zip_install_path="$install_path/syft-v$version.zip"
+  local -r bin_install_path="$install_path/bin"
+  local -r bin_path="$bin_install_path/syft"
+
+  mkdir -p "$bin_install_path"
+  local tmp_dir
+  tmp_dir="$(mktemp -d)"
+
+  echo "Downloading syft from $url"
+  curl -Ls "$url" -o "$zip_install_path"
+  unzip "$zip_install_path" -d "$tmp_dir"
+  cp "${tmp_dir}/syft" "$bin_path"
+  rm -rf "$zip_install_path"
+  rm -rf "$tmp_dir"
+  chmod +x "$bin_path"
 }
 
 install "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/bin/install
+++ b/bin/install
@@ -38,16 +38,10 @@ _get_download_url() {
   local -r version="$1"
   local -r platform="$2"
   local -r arch="$3"
-  local -r url="https://github.com/anchore/syft/releases/download/v${version}/syft_${version}_${platform}_${arch}"
+  local -r ext="$4"
+  local -r url="https://github.com/anchore/syft/releases/download/v${version}/syft_${version}_${platform}_${arch}${ext}"
 
-  case $platform in
-  linux)
-    echo "${url}.tar.gz"
-    ;;
-  darwin)
-    echo "${url}.zip"
-    ;;
-  esac
+  echo "${url}"
 }
 
 install() {
@@ -56,9 +50,8 @@ install() {
   echo "${version}, ${install_path}"
 
   local -r platform="$(_get_platform)"
-  local arch
-  arch="$(_get_arch)"
-  local -r download_url="$(_get_download_url "$version" "$platform" "$arch")"
+  local -r arch="$(_get_arch)"
+  local -r download_url="$(_get_download_url "$version" "$platform" "$arch" ".zip")"
   echo "${download_url}"
 }
 

--- a/bin/install
+++ b/bin/install
@@ -55,6 +55,9 @@ install() {
   local -r install_path=$2
   echo "${version}, ${install_path}"
 
+  local -r platform="$(_get_platform)"
+  local arch
+  arch="$(_get_arch)"
   local -r download_url="$(_get_download_url "$version" "$platform" "$arch")"
   echo "${download_url}"
 }

--- a/bin/install
+++ b/bin/install
@@ -63,17 +63,18 @@ install() {
     local -r code=$(curl -o /dev/null --silent -LIw '%{http_code}' "${tarball_url}")
     if [ "$code" = "200" ]
     then
-      install_tarball "$install_path" "$tarball_url"
+      install_tarball "$version" "$install_path" "$tarball_url"
     else
-      install_zip "$install_path" "$zip_url"
+      install_zip "$version" "$install_path" "$zip_url"
     fi
     ;;
   esac
 }
 
 install_tarball() {
-  local -r install_path=$1
-  local -r url=$2
+  local -r version=$1
+  local -r install_path=$2
+  local -r url=$3
 
   local -r tar_install_path="$install_path/syft-v$version.tgz"
   local -r bin_install_path="$install_path/bin"
@@ -93,8 +94,9 @@ install_tarball() {
 }
 
 install_zip() {
-  local -r install_path=$1
-  local -r url=$2
+  local -r version=$1
+  local -r install_path=$2
+  local -r url=$3
 
   local -r zip_install_path="$install_path/syft-v$version.zip"
   local -r bin_install_path="$install_path/bin"

--- a/bin/install
+++ b/bin/install
@@ -51,7 +51,7 @@ install() {
 
   local -r platform="$(_get_platform)"
   local -r arch="$(_get_arch)"
-  local -r download_url="$(_get_download_url "$version" "$platform" "$arch" ".zip")"
+  local -r download_url="$(_get_download_url "$version" "$platform" "$arch" ".tar.gz")"
   echo "${download_url}"
 }
 

--- a/bin/install
+++ b/bin/install
@@ -53,36 +53,10 @@ _get_download_url() {
 install() {
   local -r version=$1
   local -r install_path=$2
-  local -r tar_install_path="$install_path/syft-v$version.tgz"
-  local -r zip_install_path="$install_path/syft-v$version.zip"
-  local -r bin_install_path="$install_path/bin"
-  local -r platform="$(_get_platform)"
-  local arch
-  arch="$(_get_arch)"
+  echo "${version}, ${install_path}"
+
   local -r download_url="$(_get_download_url "$version" "$platform" "$arch")"
-  local -r bin_path="$bin_install_path/syft"
-
-  mkdir -p "$bin_install_path"
-  local tmp_dir
-  tmp_dir="$(mktemp -d)"
-  echo "Downloading syft from $download_url"
-
-  # Packaging is different for Linux and Darwin
-  case $platform in
-  linux)
-    curl -Ls "$download_url" -o "$tar_install_path"
-    tar -xf "$tar_install_path" -C "$tmp_dir"
-    ;;
-  darwin)
-    curl -Ls "$download_url" -o "$zip_install_path"
-    unzip "$zip_install_path" -d "$tmp_dir"
-    ;;
-  esac
-
-  cp "${tmp_dir}/syft" "$bin_path"
-  rm -rf "$tar_install_path"
-  rm -rf "$tmp_dir"
-  chmod +x "$bin_path"
+  echo "${download_url}"
 }
 
 install "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"


### PR DESCRIPTION
Draft fix for https://github.com/davidgp1701/asdf-syft/issues/3.

Update the `bin/install` script on `darwin` to support installing from `.tar.gz` and `.zip` archives.